### PR TITLE
fix: add orderNodesBy to knex exports

### DIFF
--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -221,3 +221,4 @@ module.exports.removeNodesFromBeginning = removeNodesFromBeginning;
 module.exports.getNodesLength = getNodesLength;
 module.exports.hasLengthGreaterThan = hasLengthGreaterThan;
 module.exports.convertNodesToEdges = convertNodesToEdges;
+module.exports.orderNodesBy = orderNodesBy;


### PR DESCRIPTION
In my project I'm overriding some relatively internal parts of the custom knex paginator, so need access to the original functions passed to the `apolloCursorPaginationBuilder` function.

Looks like `orderNodesBy` is the only one not exported!