### PR TITLE
fix: clear select before querying counts

### DIFF
--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -165,7 +165,7 @@ const removeNodesFromBeginning = (nodesAccessor, last, { orderColumn, ascOrDesc 
 
 
 const getNodesLength = async (nodesAccessor) => {
-  const counts = await nodesAccessor.clone().count('*');
+  const counts = await nodesAccessor.clone().clearSelect().count('*');
   const result = counts.reduce((prev, curr) => {
     const currCount = curr.count || curr['count(*)'];
     if (!currCount) return prev;


### PR DESCRIPTION
I noticed whenever passing a custom `.select()` to the query builder passed to this helper, whenever generating the count the original select is not cleared.

Usually, this results in the database coming back with an error message.

All I've done here is just modified the query to clear the select before performing the count.

I've tested this in my local environment and can verify it is working as expected.