### PR TITLE
feat: pass whether or not we are executing a query raw to the format function

### DIFF
--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -36,9 +36,9 @@ const getDataFromCursor = (cursor) => {
   return [data[0], values];
 };
 
-const formatColumnIfAvailable = (column, formatColumnFn) => {
+const formatColumnIfAvailable = (column, formatColumnFn, isRaw = true) => {
   if (formatColumnFn) {
-    return formatColumnFn(column);
+    return formatColumnFn(column, isRaw);
   }
   return column;
 };
@@ -121,12 +121,12 @@ const orderNodesBy = (nodesAccessor, { orderColumn = 'id', ascOrDesc = 'asc', fo
   const initialValue = nodesAccessor.clone();
   const result = operateOverScalarOrArray(initialValue, orderColumn, (orderBy, index, prev) => {
     if (index !== null) {
-      return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc[index]);
+      return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn, false), ascOrDesc[index]);
     }
-    return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc);
+    return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn, false), ascOrDesc);
   }, (prev, isArray) => (isArray
-    ? prev.orderBy(formatColumnIfAvailable('id', formatColumnFn), ascOrDesc[0])
-    : prev.orderBy(formatColumnIfAvailable('id', formatColumnFn), ascOrDesc)));
+    ? prev.orderBy(formatColumnIfAvailable('id', formatColumnFn, false), ascOrDesc[0])
+    : prev.orderBy(formatColumnIfAvailable('id', formatColumnFn, false), ascOrDesc)));
   return result;
 };
 


### PR DESCRIPTION
I'm back with another request :)

I've recently come across a bug where I need more information about the context in which the `formatColumnFn` is called (that context being whether or not the column is needed in a raw context or not, which tells me if I need to add quotes manually to the column or not).

Just a quick little addition! Tested this in my staging environment and appears to be working fine.