### PR TITLE
fix: support special characters in cursor generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "author": "Daniel Merrill <daniel@terminal.co>",
   "license": "MIT",
   "private": false,
-  "dependencies": {
-    "base-64": "^0.1.0"
-  },
   "scripts": {
     "build": "babel src --out-dir dist"
   },

--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -1,11 +1,10 @@
-const base64 = require('base-64');
 const apolloCursorPaginationBuilder = require('../../builder');
 
 const SEPARATION_TOKEN = '_*_';
 const ARRAY_DATA_SEPARATION_TOKEN = '_%_';
 
-const encode = str => base64.encode(str);
-const decode = str => base64.decode(str);
+const encode = str => Buffer.from(str).toString('base64');
+const decode = str => Buffer.from(str, 'base64').toString();
 
 const operateOverScalarOrArray = (initialValue, scalarOrArray, operation, operateResult) => {
   let result = initialValue;

--- a/src/orm-connectors/knex/offset-based-pagination.js
+++ b/src/orm-connectors/knex/offset-based-pagination.js
@@ -1,4 +1,3 @@
-const base64 = require('base-64');
 const apolloCursorPaginationBuilder = require('../../builder');
 
 /**
@@ -13,8 +12,8 @@ const apolloCursorPaginationBuilder = require('../../builder');
 
 const SEPARATION_TOKEN = '___';
 
-const encode = str => base64.encode(str);
-const decode = str => base64.decode(str);
+const encode = str => Buffer.from(str).toString('base64');
+const decode = str => Buffer.from(str, 'base64').toString();
 
 const cursorGenerator = (id, offset) => encode(`${id}${SEPARATION_TOKEN}${offset}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,11 +899,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
-
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"


### PR DESCRIPTION
While using this in production, we were running into errors whenever users were sorting by a name field with a special character in the name. This is because the base-64 package being used in this package doesn't support special characters.

This PR replaces the use of the base-64 package with the built-in Buffer library (which supports conversion to / from base64 out of the box).

When testing this in production, it seems to be working fine.

Here is a sample string that failed the cursor generation: `First ⇰ Tag`